### PR TITLE
Display warning banner for prerelease/unreleased versions

### DIFF
--- a/supplemental-files/rancher/partials/article.hbs
+++ b/supplemental-files/rancher/partials/article.hbs
@@ -1,0 +1,25 @@
+<article class="doc">
+{{! Custom changes start}}
+{{#if page.componentVersion.prerelease}}
+<div class="admonitionblock warning">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-warning" title="Warning"></i>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>This is unreleased documentation for {{page.component.title}} {{page.componentVersion.displayVersion}}.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+{{/if}}
+{{! Custom changes end}}
+{{#with page.title}}
+<h1 class="page">{{{this}}}</h1>
+{{/with}}
+{{{page.contents}}}
+{{> pagination}}
+</article>


### PR DESCRIPTION
## Description

Adds a warning banner indicating that a given documentation version set is unreleased. The banner displays when a component's antora.yml has the `prerelease` value set. All pages within the version have the banner at the top, similar to our Community docs.

The existing warning admonition is used for the banner. Implementation wise, I could not figure out a cleaner solution so the admonition HTML is hard coded.

Examples:

![prerelease-banner-1](https://github.com/user-attachments/assets/b71d3e84-21d5-4a7c-8dc6-b3666f7bce07)

![prerelease-banner-2](https://github.com/user-attachments/assets/cc4c2fbf-c6dc-4542-8ce6-fd9003c4e16d)
