### PR TITLE
Revert "Have the toc-menu encompass tocTitle and data levels."

### DIFF
--- a/supplemental-files/rancher/partials/toc.hbs
+++ b/supplemental-files/rancher/partials/toc.hbs
@@ -1,7 +1,7 @@
 <aside
   class="toc sidebar"
+  data-title="{{{or page.attributes.toctitle (tocTitleForLang (langFromUrl page.url 'lang' this))}}}" data-levels="{{{or page.attributes.toclevels 2}}}">
   <div class="toc-menu">
-    data-title="{{{or page.attributes.toctitle (tocTitleForLang (langFromUrl page.url 'lang' this))}}}" data-levels="{{{or page.attributes.toclevels 2}}}">
     <!-- start qualtrics -->
     <div id='ZN_8qZUmklKYbBqAYe'><!--DO NOT REMOVE-CONTENTS PLACED HERE--></div>
     <div id="qualtrics_container"></div>


### PR DESCRIPTION
Reverts SUSEdoc/dsc-style-bundle#60, , that was bad.