### PR TITLE
Adding support for Mermaid render in footer-script partial

### DIFF
--- a/supplemental-files/rancher/partials/footer-scripts.hbs
+++ b/supplemental-files/rancher/partials/footer-scripts.hbs
@@ -8,3 +8,25 @@
 
 
 <script src="{{{uiRootPath}}}/js/CNLanguageSwitcher.js"></script>
+
+<script type="module">
+
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+
+document.querySelectorAll('pre code.language-mermaid').forEach((block) => {
+
+const parent = block.parentElement;
+const div = document.createElement('div');
+div.className = 'mermaid';
+div.textContent = block.textContent;
+parent.replaceWith(div);
+
+});
+
+ mermaid.initialize({
+    startOnLoad: true,
+    securityLevel: 'loose',
+    theme: 'default'
+ });
+
+</script>


### PR DESCRIPTION
I noticed, mermaid images weren't rendering correctly. For example,

- It renders correctly in https://documentation.suse.com/cloudnative/continuous-delivery/v0.15/en/reference/ref-registration.html#_registration_flow 
- It doesn't render correctly in https://fleet.rancher.io/0.15/reference/ref-registration#_registration_flow