### PR TITLE
Update Version Selector Button - Mobile View

### DIFF
--- a/supplemental-files/rancher/css/site-extra.css
+++ b/supplemental-files/rancher/css/site-extra.css
@@ -1464,6 +1464,46 @@ nav.pagination a {
   }
 }
 
+@media screen and (max-width: 1023px) {
+  /* 1. Ensure the NAV-TOGGLE button is not compressed beyond user visibility (The Mobile Menu Hamburger) */
+  button.nav-toggle {
+    display: block !important;
+    visibility: visible !important;
+    flex-shrink: 0 !important; /* Strictly forbids the layout engine from compressing this button */
+    width: 44px !important;    /* Standard click target sizing */
+    height: 44px !important;
+    min-width: 44px !important;
+  }
+
+  /* 2. Ensure the VERSION-MENU button is not compressed beyond user visibility */
+  button.version-menu-toggle {
+    white-space: nowrap !important;
+    flex-shrink: 0 !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+    min-width: max-content !important;
+    width: auto !important;
+    padding-left: 12px !important;
+    padding-right: 12px !important;
+    gap: 8px !important; /* Enforces clean horizontal breathing room before the carrot icon */
+  }
+
+  /* 3. Ensure the CARROT / ARROW INDICATOR is not compressed beyond user visibility */
+  /* This targets pseudo-elements (like standard Antora arrows) as well as explicitly injected child icons */
+  button.version-menu-toggle::after,
+  button.version-menu-toggle .icon,
+  button.version-menu-toggle svg,
+  button.version-menu-toggle img {
+    display: inline-block !important;
+    flex-shrink: 0 !important; /* Force the layout engine to leave the carrot aspect ratio uncompressed */
+    width: 10px !important;    /* Forces explicit structural size if it lost its square footprint */
+    height: 10px !important;
+    min-width: 10px !important;
+    content: "" !important;    /* Ensures pseudo-elements maintain structural integrity */
+  }
+}
+
 .nav {
   top: 6.8rem;
   -webkit-box-shadow: none;


### PR DESCRIPTION
Adding CSS override in site-extra.css to handle version selector button text compression in mobile view. Can be tested when previewing site and using the developer tools to view either Iphone or other mobile view size presets.